### PR TITLE
Add `fail-under-line` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use this action
         uses: ./
 
-  root-input:
+  use-action-from-different-root:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -35,8 +35,9 @@ jobs:
         uses: ./
         with:
           root: test
+          fail-under-line: 100
 
-  exclude-input:
+  use-action-with-exclusion:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -53,3 +54,4 @@ jobs:
         uses: ./
         with:
           exclude: test/include/*
+          fail-under-line: 100

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,17 @@ jobs:
           cmake --build build
           ctest --test-dir build
 
-      - name: Use this action
+      - name: Use this action without exclusion
+        id: failed_action
+        continue-on-error: true
+        uses: ./
+        with:
+          fail-under-line: 100
+
+      - name: Check if previous step is failing
+        run: ${{ steps.failed_action.outcome == 'failure' && true || false }}
+
+      - name: Use this action with exclusion
         uses: ./
         with:
           exclude: test/include/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           ctest --test-dir build
 
       - name: Use this action from build root
-        id: failed_action
+        id: failed_step
         continue-on-error: true
         uses: ./
         with:
@@ -40,7 +40,7 @@ jobs:
           fail-under-line: 100
 
       - name: Check if previous step is failing
-        run: ${{ steps.failed_action.outcome == 'failure' && true || false }}
+        run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
 
       - name: Use this action from project root
         uses: ./
@@ -62,14 +62,14 @@ jobs:
           ctest --test-dir build
 
       - name: Use this action without exclusion
-        id: failed_action
+        id: failed_step
         continue-on-error: true
         uses: ./
         with:
           fail-under-line: 100
 
       - name: Check if previous step is failing
-        run: ${{ steps.failed_action.outcome == 'failure' && true || false }}
+        run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
 
       - name: Use this action with exclusion
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,18 @@ jobs:
           cmake --build build
           ctest --test-dir build
 
-      - name: Use this action
+      - name: Use this action from build root
+        id: failed_action
+        continue-on-error: true
+        uses: ./
+        with:
+          root: test/build
+          fail-under-line: 100
+
+      - name: Check if previous step is failing
+        run: ${{ steps.failed_action.outcome == 'failure' && true || false }}
+
+      - name: Use this action from project root
         uses: ./
         with:
           root: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Check if previous step is failing
         run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
 
+      - name: Use this action from build root but without fail threshold
+        uses: ./
+        with:
+          root: test/build
+
       - name: Use this action from project root
         uses: ./
         with:
@@ -70,6 +75,11 @@ jobs:
 
       - name: Check if previous step is failing
         run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
+
+      - name: Use this action without exclusion but with lower fail threshold
+        uses: ./
+        with:
+          fail-under-line: 50
 
       - name: Use this action with exclusion
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   exclude:
     description: 'Exclude source files that match this filter'
     required: false
+  fail-under-line:
+    description: 'Exit with a status of 2 if the total line coverage is less than this value'
+    required: false
 branding:
   color: green
   icon: terminal
@@ -22,6 +25,8 @@ runs:
         fi
         root=${{ inputs.root }}
         exclude=${{ inputs.exclude }}
+        fail_ul=${{ inputs.fail-under-line }}
         gcovr \
           ${root:+ --root "$root"} \
-          ${exclude:+ --exclude "$exclude"}
+          ${exclude:+ --exclude "$exclude"} \
+          ${fail_ul:+ --fail-under-line "$fail_ul"}


### PR DESCRIPTION
Closes #6 

- Add `fail-under-line` input option.
- Modify jobs in the test workflow to accommodate `fail-under-line` testing by:
  - Rename job by objective instead of by what input is being tested.
  - Run action on a failed case.