### PR TITLE
Add `gcov-executable` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,26 @@ jobs:
       - name: Use this action
         uses: ./
 
+  use-action-llvm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.2.0
+
+      - name: Install LLVM
+        run: sudo apt install -y llvm
+
+      - name: Build and test example project
+        run:  |
+          cmake test -B build -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build
+          ctest --test-dir build
+
+      - name: Use this action
+        uses: ./
+        with:
+          gcov-executable: llvm-cov gcov
+
   use-action-from-different-root:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   root:
     description: 'The root directory of your source files'
     required: false
+  gcov-executable:
+    description: 'Use a particular gcov executable'
+    required: false
   exclude:
     description: 'Exclude source files that match this filter'
     required: false
@@ -29,9 +32,11 @@ runs:
       shell: bash
       run: |
         root=${{ inputs.root }}
+        gcov_exec=${{ inputs.gcov-executable }}
         exclude=${{ inputs.exclude }}
         fail_ul=${{ inputs.fail-under-line }}
         gcovr \
           ${root:+ --root "$root"} \
+          ${gcov_exec:+ --gcov-executable "$gcov_exec"} \
           ${exclude:+ --exclude "$exclude"} \
           ${fail_ul:+ --fail-under-line "$fail_ul"}

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ runs:
     - name: Generate code coverage report using gcovr
       shell: bash
       run: |
-        root=${{ inputs.root }}
-        gcov_exec=${{ inputs.gcov-executable }}
-        exclude=${{ inputs.exclude }}
-        fail_ul=${{ inputs.fail-under-line }}
+        root="${{ inputs.root }}"
+        gcov_exec="${{ inputs.gcov-executable }}"
+        exclude="${{ inputs.exclude }}"
+        fail_ul="${{ inputs.fail-under-line }}"
         gcovr \
           ${root:+ --root "$root"} \
           ${gcov_exec:+ --gcov-executable "$gcov_exec"} \


### PR DESCRIPTION
Closes #10 

- Add `gcov-executable` input option.
- Add job in the `test.yml` to test code coverage report generation if a project is build using [LLVM](https://llvm.org/).
- Fix to add quotation mark in the input to capture non quoted input.