### PR TITLE
Add `coveralls-out` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,3 +106,23 @@ jobs:
         with:
           exclude: test/include/*
           fail-under-line: 100
+
+  use-action-generate-coveralls:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.2.0
+
+      - name: Build and test example project
+        run:  |
+          cmake test -B build
+          cmake --build build
+          ctest --test-dir build
+
+      - name: Use this action to generate Coveralls report
+        uses: ./
+        with:
+          coveralls-out: coveralls.json
+
+      - name: Check if Coveralls report exist
+        run: cat coveralls.json

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   fail-under-line:
     description: 'Exit with a status of 2 if the total line coverage is less than this value'
     required: false
+  coveralls-out:
+    description: 'Output of generated Coveralls API coverage report'
+    required: false
 branding:
   color: green
   icon: terminal
@@ -35,8 +38,10 @@ runs:
         gcov_exec="${{ inputs.gcov-executable }}"
         exclude="${{ inputs.exclude }}"
         fail_ul="${{ inputs.fail-under-line }}"
+        coveralls_out="${{ inputs.coveralls-out }}"
         gcovr \
           ${root:+ --root "$root"} \
           ${gcov_exec:+ --gcov-executable "$gcov_exec"} \
           ${exclude:+ --exclude "$exclude"} \
-          ${fail_ul:+ --fail-under-line "$fail_ul"}
+          ${fail_ul:+ --fail-under-line "$fail_ul"} \
+          ${coveralls_out:+ --coveralls "$coveralls_out"}


### PR DESCRIPTION
Closes #7 

- Add `coveralls-out` input option.
- Add job in the `test.yml` workflow to test this input.