### PR TITLE
Add `coveralls-send` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,11 +129,15 @@ jobs:
 
       - name: Use this action to generate and send Coveralls report
         uses: ./
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           coveralls-send: true
 
       - name: Use this action to generate and send Coveralls report on specified output
         uses: ./
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           coveralls-send: true
           coveralls-out: coveralls-2.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,18 +129,16 @@ jobs:
 
       - name: Use this action to generate and send Coveralls report
         uses: ./
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           coveralls-send: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use this action to generate and send Coveralls report on specified output
         uses: ./
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
-          coveralls-send: true
           coveralls-out: coveralls-2.json
+          coveralls-send: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if Coveralls report exist
         run: cat coveralls-2.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,14 +131,14 @@ jobs:
         uses: ./
         with:
           coveralls-send: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coveralls-repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       - name: Use this action to generate and send Coveralls report on specified output
         uses: ./
         with:
           coveralls-out: coveralls-2.json
           coveralls-send: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coveralls-repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       - name: Check if Coveralls report exist
         run: cat coveralls-2.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,3 +126,17 @@ jobs:
 
       - name: Check if Coveralls report exist
         run: cat coveralls.json
+
+      - name: Use this action to generate and send Coveralls report
+        uses: ./
+        with:
+          coveralls-send: true
+
+      - name: Use this action to generate and send Coveralls report on specified output
+        uses: ./
+        with:
+          coveralls-send: true
+          coveralls-out: coveralls-2.json
+
+      - name: Check if Coveralls report exist
+        run: cat coveralls-2.json

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,6 @@ runs:
       run: gcovr ${{ env.GCOVR_ARGS }}
 
     - name: Send code coverage report to Coveralls
-      if: ${{ env.COVERALLS_OUT == 'true' }}
+      if: ${{ inputs.coveralls-send == 'true' }}
       shell: bash
       run: curl -v -F json_file=@${{ env.COVERALLS_OUT }} https://coveralls.io/api/v1/jobs

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   coveralls-out:
     description: 'Output of generated Coveralls API coverage report'
     required: false
+  coveralls-send:
+    description: Send Coveralls API coverage report into it's endpoint (true/false)
+    required: false
+    default: false
 branding:
   color: green
   icon: terminal
@@ -47,10 +51,21 @@ runs:
           ARGS="$ARGS --fail-under-line '${{ inputs.fail-under-line }}'"
         fi
         if [ -n '${{ inputs.coveralls-out }}' ]; then
-          ARGS="$ARGS --coveralls '${{ inputs.coveralls-out }}'"
+          COVERALLS_OUT='${{ inputs.coveralls-out }}'
+        elif [ '${{ inputs.coveralls-send }}' = 'true' ]; then
+          COVERALLS_OUT='/tmp/coveralls.json'
+        fi
+        if [ -n "$COVERALLS_OUT" ]; then
+          ARGS="$ARGS --coveralls $COVERALLS_OUT"
         fi
         echo "GCOVR_ARGS=$ARGS" >> $GITHUB_ENV
+        echo "COVERALLS_OUT=$COVERALLS_OUT" >> $GITHUB_ENV
 
     - name: Generate code coverage report using gcovr
       shell: bash
       run: gcovr ${{ env.GCOVR_ARGS }}
+
+    - name: Send code coverage report to Coveralls
+      if: ${{ env.COVERALLS_OUT == 'true' }}
+      shell: bash
+      run: curl -v -F json_file=@${{ env.COVERALLS_OUT }} https://coveralls.io/api/v1/jobs

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Exit with a status of 2 if the total line coverage is less than this value'
     required: false
   coveralls-out:
-    description: 'Output of generated Coveralls API coverage report'
+    description: Output file of generated Coveralls API coverage report
     required: false
   coveralls-send:
-    description: Send Coveralls API coverage report into it's endpoint (true/false)
+    description: Send Coveralls API coverage report to it's endpoint (true/false)
     required: false
     default: false
   coveralls-repo-token:

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: Send Coveralls API coverage report into it's endpoint (true/false)
     required: false
     default: false
-  github-token:
+  coveralls-repo-token:
     description: Required for sending Coveralls API coverage report successfully
     required: false
 branding:
@@ -67,7 +67,7 @@ runs:
     - name: Generate code coverage report using gcovr
       shell: bash
       env:
-        COVERALLS_REPO_TOKEN: ${{ inputs.github-token }}
+        COVERALLS_REPO_TOKEN: ${{ inputs.coveralls-repo-token }}
       run: gcovr ${{ env.GCOVR_ARGS }}
 
     - name: Send code coverage report to Coveralls

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: Send Coveralls API coverage report into it's endpoint (true/false)
     required: false
     default: false
+  github-token:
+    description: Required for sending Coveralls API coverage report successfully
+    required: false
 branding:
   color: green
   icon: terminal
@@ -63,6 +66,8 @@ runs:
 
     - name: Generate code coverage report using gcovr
       shell: bash
+      env:
+        COVERALLS_REPO_TOKEN: ${{ inputs.github-token }}
       run: gcovr ${{ env.GCOVR_ARGS }}
 
     - name: Send code coverage report to Coveralls


### PR DESCRIPTION
Closes #14 

- Add `coveralls-send` input option.
- Modify `use-action-generate-coveralls` job in the `test.yml` workflow to test this input.