### PR TITLE
Audit Code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,11 @@ jobs:
           gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
 
   exclusion-usage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
 
-  specified-root-usage:
+  exclusion-usage:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -61,50 +61,16 @@ jobs:
       - name: Build and test the test project
         working-directory: test
         run:  |
-          cmake . -B build
-          cmake --build build
-          ctest --test-dir build
-
-      - name: Use this action from the build root
-        id: failed_step
-        continue-on-error: true
-        uses: ./
-        with:
-          root: test/build
-          fail-under-line: 100
-
-      - name: Check if the previous step did fail
-        run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
-
-      - name: Use this action from the build root but without a fail threshold
-        uses: ./
-        with:
-          root: test/build
-
-      - name: Use this action from the project root
-        uses: ./
-        with:
-          root: test
-          fail-under-line: 100
-
-  excusion-usage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v3.3.0
-
-      - name: Build and test the test project
-        working-directory: test
-        run:  |
-          cmake . -B build -DTEST_EVEN=OFF -DTEST_ODD=OFF
-          cmake --build build
-          ctest --test-dir build
+          cmake test/ -B test/build -DTEST_EVEN=OFF -DTEST_ODD=OFF
+          cmake --build test/build
+          ctest --test-dir test/build
 
       - name: Use this action without an exclusion
         id: failed_step
         continue-on-error: true
         uses: ./
         with:
+          root: test
           fail-under-line: 100
 
       - name: Check if the previous step did fail
@@ -113,11 +79,13 @@ jobs:
       - name: Use this action without an exclusion but with a lower fail threshold
         uses: ./
         with:
+          root: test
           fail-under-line: 50
 
       - name: Use this action with an exclusion
         uses: ./
         with:
+          root: test
           exclude: test/include/*
           fail-under-line: 100
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,17 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Build and test the test project
-        working-directory: test
-        run:  |
-          cmake test/ -B test/build -DTEST_EVEN=OFF -DTEST_ODD=OFF
-          cmake --build test/build
-          ctest --test-dir test/build
+      - name: Configure and build the test project
+        uses: threeal/cmake-action@v1.0.0
+        with:
+          source-dir: test
+          build-dir: test/build
+          generator: Ninja
+          cxx-compiler: g++
+          args: -DTEST_EVEN=OFF -DTEST_ODD=OFF
+
+      - name: Test the test project
+        run: ctest --test-dir test/build
 
       - name: Use this action without an exclusion
         id: failed_step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,40 +3,40 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  use-action:
+  standard-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Configure and build the example project
+      - name: Configure and build the test project
         uses: threeal/cmake-action@v1.0.0
         with:
           source-dir: test
           generator: Ninja
           cxx-compiler: g++
 
-      - name: Test the example project
+      - name: Test the test project
         run: ctest --test-dir build
 
       - name: Use this action
         uses: ./
 
-  use-action-llvm:
+  llvm-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Configure and build the example project
+      - name: Configure and build the test project
         uses: threeal/cmake-action@v1.0.0
         with:
           source-dir: test
@@ -44,28 +44,28 @@ jobs:
           c-compiler: clang
           cxx-compiler: clang++
 
-      - name: Test the example project
+      - name: Test the test project
         run: ctest --test-dir build
 
-      - name: Use this action with specified gcov executable
+      - name: Use this action with llvm-cov as the gcov executable
         uses: ./
         with:
           gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
 
-  use-action-from-different-root:
+  specified-root-usage:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Build and test example project
+      - name: Build and test the test project
         working-directory: test
         run:  |
           cmake . -B build
           cmake --build build
           ctest --test-dir build
 
-      - name: Use this action from build root
+      - name: Use this action from the build root
         id: failed_step
         continue-on-error: true
         uses: ./
@@ -73,94 +73,94 @@ jobs:
           root: test/build
           fail-under-line: 100
 
-      - name: Check if previous step is failing
+      - name: Check if the previous step did fail
         run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
 
-      - name: Use this action from build root but without fail threshold
+      - name: Use this action from the build root but without a fail threshold
         uses: ./
         with:
           root: test/build
 
-      - name: Use this action from project root
+      - name: Use this action from the project root
         uses: ./
         with:
           root: test
           fail-under-line: 100
 
-  use-action-with-exclusion:
+  excusion-usage:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Build and test example project
+      - name: Build and test the test project
         working-directory: test
         run:  |
           cmake . -B build -DTEST_EVEN=OFF -DTEST_ODD=OFF
           cmake --build build
           ctest --test-dir build
 
-      - name: Use this action without exclusion
+      - name: Use this action without an exclusion
         id: failed_step
         continue-on-error: true
         uses: ./
         with:
           fail-under-line: 100
 
-      - name: Check if previous step is failing
+      - name: Check if the previous step did fail
         run: ${{ steps.failed_step.outcome == 'failure' && true || false }}
 
-      - name: Use this action without exclusion but with lower fail threshold
+      - name: Use this action without an exclusion but with a lower fail threshold
         uses: ./
         with:
           fail-under-line: 50
 
-      - name: Use this action with exclusion
+      - name: Use this action with an exclusion
         uses: ./
         with:
           exclude: test/include/*
           fail-under-line: 100
 
-  use-action-generate-coveralls:
+  coveralls-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Checkout repository
+      - name: Checkout this repository
         uses: actions/checkout@v3.3.0
 
-      - name: Configure and build the example project
+      - name: Configure and build the test project
         uses: threeal/cmake-action@v1.0.0
         with:
           source-dir: test
           generator: Ninja
           cxx-compiler: g++
 
-      - name: Test the example project
+      - name: Test the test project
         run: ctest --test-dir build
 
-      - name: Use this action to generate Coveralls report
+      - name: Use this action to generate a Coveralls report
         uses: ./
         with:
           coveralls-out: coveralls.json
 
-      - name: Check if Coveralls report exist
+      - name: Check if that Coveralls report does exist
         run: cat coveralls.json
 
-      - name: Use this action to generate and send Coveralls report
+      - name: Use this action to generate and send another Coveralls report
         uses: ./
         with:
           coveralls-send: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Use this action to generate and send Coveralls report on specified output
+      - name: Use this action to generate and send another Coveralls report on a specified output
         uses: ./
         with:
           coveralls-out: coveralls-2.json
           coveralls-send: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if Coveralls report exist
+      - name: Check if that Coveralls report does exist
         run: cat coveralls-2.json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | Name | Value Type | Description |
 | --- | --- | --- |
 | `root` | Path | Root directory of your source files. Defaults to current directory. File names are reported relative to this directory. |
-| `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM](https://llvm.org/). See [this](https://docs.coveralls.io/api-introduction). |
+| `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM](https://llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
 | `exclude` | Regular expression | Exclude source files that match this filter. |
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 Generate code coverage reports for a C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).
 
+## Features
+
+- Generate code coverage reports using [gcovr](https://gcovr.com/en/stable/).
+- Generate and send reports in [Coveralls API](https://docs.coveralls.io/api-introduction) format.
+- Auto detect and install required dependencies.
+- Support coverage report on [GCC](https://gcc.gnu.org/) and [LLVM Clang](https://clang.llvm.org/).
+- Support files exclusion and fail if coverage is below a specific thresold.
+
 ## Usage
 
 For more information, see [action.yml](./action.yml) and [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions).

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 
 | Name | Value Type | Description |
 | --- | --- | --- |
-| `root` | Path | The root directory of your source files. Defaults to current directory. File names are reported relative to this root. |
+| `root` | Path | Root directory of your source files. Defaults to current directory. File names are reported relative to this directory. |
 | `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM](https://llvm.org/). See [this](https://docs.coveralls.io/api-introduction). |
 | `exclude` | Regular expression | Exclude source files that match this filter. |
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
-| `coveralls-out` | Path | Output file of generated Coveralls API coverage report. |
-| `coveralls-send` | `true` or `false` | Send Coveralls API coverage report to it's endpoint (default: `false`). |
-| `github-token` | Token | GitHub token of this project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
+| `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
+| `coveralls-send` | `true` or `false` | Send the generated Coveralls API coverage report to it's endpoint. Defaults to `false`. |
+| `github-token` | Token | GitHub token of your project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
 
 > Note: All inputs are optional.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
 | `coveralls-send` | `true` or `false` | Send the generated Coveralls API coverage report to it's endpoint. Defaults to `false`. |
-| `github-token` | Token | GitHub token of your project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
+| `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
 
 > Note: All inputs are optional.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | Name | Value Type | Description |
 | --- | --- | --- |
 | `root` | Path | Root directory of your source files. Defaults to current directory. File names are reported relative to this directory. |
-| `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM](https://llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
+| `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM Clang](https://clang.llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
 | `exclude` | Regular expression | Exclude source files that match this filter. |
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
@@ -57,7 +57,7 @@ jobs:
 
 > Note: You can replace `@latest` with any version you like.
 
-#### Using LLVM
+#### Using LLVM Clang
 
 ```yaml
 - name: Build and test this project

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Check out this repository
         uses: actions/checkout@v3.2.0
 
-      - name: Build and test project
+      - name: Build and test this project
         run: |
           cmake . -B build
           cmake --build build
           ctest --test-dir build
 
-      - name: Generate code coverage report
+      - name: Generate a code coverage report
         uses: threeal/gcovr-action@latest
 ```
 
@@ -52,13 +52,13 @@ jobs:
 #### Using LLVM
 
 ```yaml
-- name: Build and test project
+- name: Build and test this project
   run: |
     cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     cmake --build build
     ctest --test-dir build
 
-- name: Generate code coverage report
+- name: Generate a code coverage report
   uses: threeal/gcovr-action@latest
   with:
     gcov-executable: llvm-cov gcov
@@ -67,7 +67,7 @@ jobs:
 #### Send to Coveralls
 
 ```yaml
-- name: Generate and send code coverage report to Coveralls
+- name: Generate and send a code coverage report to Coveralls
   uses: threeal/gcovr-action@latest
   with:
     coveralls-send: true

--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ jobs:
 
 ## License
 
-This project is maintained by [Alfi Maulana](https://github.com/threeal) and licensed under the [MIT License](./LICENSE).
+This project is licensed under the terms of the [MIT License](./LICENSE).
+
+Copyright © 2022-2023 [Alfi Maulana](https://github.com/threeal/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
 | `coveralls-send` | `true` or `false` | Send the generated Coveralls API coverage report to it's endpoint. Defaults to `false`. |
-| `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
+| `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Should be set to `secrets.GITHUB_TOKEN`. Required for sending Coveralls API coverage report successfully. |
 
 > Note: All inputs are optional.
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ Generate code coverage reports for a C++ project on [GitHub Actions](https://git
 
 ## Usage
 
-For more information, see [action.yml](./action.yml) and the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions).
+For more information, see [action.yml](./action.yml) and [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions).
 
 ### Inputs
-
-> Note: All inputs are optional.
 
 | Name | Value Type | Description |
 | --- | --- | --- |
@@ -24,7 +22,9 @@ For more information, see [action.yml](./action.yml) and the [GitHub Actions gui
 | `coveralls-send` | `true` or `false` | Send Coveralls API coverage report to it's endpoint (default: `false`). |
 | `github-token` | Token | GitHub token of this project. Must be set to `${{ secrets.GITHUB_TOKEN }}`. Required for sending Coveralls API coverage report successfully. |
 
-### Standard Example
+> Note: All inputs are optional.
+
+### Examples
 
 ```yaml
 name: test
@@ -47,7 +47,9 @@ jobs:
         uses: threeal/gcovr-action@latest
 ```
 
-### Using LLVM
+> Note: You can replace `@latest` with any version you like.
+
+#### Using LLVM
 
 ```yaml
 - name: Build and test project
@@ -62,7 +64,7 @@ jobs:
     gcov-executable: llvm-cov gcov
 ```
 
-### Send to Coveralls
+#### Send to Coveralls
 
 ```yaml
 - name: Generate and send code coverage report to Coveralls

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/github/license/threeal/gcovr-action)](./LICENSE)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/test.yml?label=test&branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/test.yml)
 
-Generate code coverage report for C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).
+Generate code coverage reports for a C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | Name | Value Type | Description |
 | --- | --- | --- |
 | `root` | Path | Root directory of your source files. Defaults to current directory. File names are reported relative to this directory. |
-| `gcov-executable` | Executable name with optional arguments | Use a particular gcov executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM Clang](https://clang.llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
+| `gcov-executable` | Executable name with optional arguments | Use a particular [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM Clang](https://clang.llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
 | `exclude` | Regular expression | Exclude source files that match this filter. |
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
         uses: threeal/gcovr-action@latest
 ```
 
-> Note: You can replace `@latest` with any version you like.
+> Note: You can replace `@latest` with any version you like. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
 #### Using LLVM Clang
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Gcovr Action
-description: Generate code coverage report for C++ project using gcovr
+description: Generate code coverage reports for a C++ project using gcovr
 author: Alfi Maulana
 branding:
   color: green

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: check-circle
 inputs:
   root:
-    description: The root directory of your source files
+    description: Root directory of your source files
     required: false
   gcov-executable:
     description: Use a particular gcov executable
@@ -18,10 +18,10 @@ inputs:
     description: Fail if the total line coverage is less than this value
     required: false
   coveralls-out:
-    description: Output file of generated Coveralls API coverage report
+    description: Output file of the generated Coveralls API coverage report
     required: false
   coveralls-send:
-    description: Send Coveralls API coverage report to it's endpoint (true/false)
+    description: Send the generated Coveralls API coverage report to it's endpoint (true/false)
     required: false
     default: false
   github-token:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,12 +8,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -O0")
 
 add_executable(main main.cpp)
 target_include_directories(main PRIVATE include)
-if(TEST_EVEN)
-  target_compile_definitions(main PRIVATE TEST_EVEN)
-endif()
-if(TEST_ODD)
-  target_compile_definitions(main PRIVATE TEST_ODD)
-endif()
+target_compile_definitions(
+  main PRIVATE
+  $<$<BOOL:${TEST_EVEN}>:TEST_EVEN>
+  $<$<BOOL:${TEST_ODD}>:TEST_ODD>
+)
 
 enable_testing()
 add_test(NAME main COMMAND $<TARGET_FILE:main>)


### PR DESCRIPTION
- Fix wording in description, name, and other places.
- Use CMake generator expressions when setting compile definitions of the test project.
- Merge `specified-root-usage` job into `exclusion-usage` job.
- Make `exclusion-usage` job use [CMake action](github.com/threeal/cmake-action) and run on multiple platforms.