### PR TITLE
Check npm Package Using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Add support in the [Dependabot](https://github.com/dependabot) to check for [npm](https://www.npmjs.com/) package updates.