### PR TITLE
Separate Check Build Step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,10 @@ jobs:
         with:
           name: project
           if-no-files-found: error
-          path: '*'
+          path: |
+            *
+            !lib/
+            !node_modules/
 
   check-build:
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,22 @@ jobs:
       - name: Build this package for distribution
         run: npm run package
 
-      - name: Upload the distribution as an artifact
+      - name: Upload this project as an artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: dist
+          name: project
           if-no-files-found: error
-          path: |
-            .git/
-            dist/
-            sample/
-            action.yml
+          path: '*'
 
   check-build:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download the project artifact
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: project
+
       - name: Check if the distribution is up to date
         run: git diff --exit-code HEAD
 
@@ -50,10 +51,10 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Download the distribution artifact
+      - name: Download the project artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: dist
+          name: project
 
       - name: Configure, build, and test the sample project
         uses: threeal/cmake-action@v1.1.0
@@ -85,10 +86,10 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Download the distribution artifact
+      - name: Download the project artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: dist
+          name: project
 
       - name: Configure, build, and test the sample project
         uses: threeal/cmake-action@v1.1.0
@@ -112,10 +113,10 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Download the distribution artifact
+      - name: Download the project artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: dist
+          name: project
 
       - name: Configure, build, and test the sample project
         uses: threeal/cmake-action@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  build:
+  distribute:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -28,14 +28,13 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: project
-          if-no-files-found: error
           path: |
             *
             !lib/
             !node_modules/
 
-  check-build:
-    needs: build
+  check-distribution:
+    needs: distribute
     runs-on: ubuntu-latest
     steps:
       - name: Download the project artifact
@@ -47,7 +46,7 @@ jobs:
         run: git diff --exit-code HEAD
 
   standard-usage:
-    needs: build
+    needs: distribute
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -67,22 +66,20 @@ jobs:
           cxx-compiler: g++
           run-test: true
 
-      - name: Upload the distribution with build as an artifact
+      - name: Upload this project as an artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: dist-with-build-${{ matrix.os }}
-          if-no-files-found: error
+          name: project-with-build-${{ matrix.os }}
           path: |
-            .git/
-            dist/
-            sample/
-            action.yml
+            *
+            !lib/
+            !node_modules/
 
       - name: Use this action
         uses: ./
 
   llvm-usage:
-    needs: build
+    needs: distribute
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -109,7 +106,7 @@ jobs:
           gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
 
   exclusion-usage:
-    needs: build
+    needs: distribute
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -162,10 +159,10 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Download the distribution with build artifact
+      - name: Download the project artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: dist-with-build-${{ matrix.os }}
+          name: project-with-build-${{ matrix.os }}
 
       - name: Use this action to generate a Coveralls report
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  check-build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -24,9 +24,6 @@ jobs:
       - name: Build this package for distribution
         run: npm run package
 
-      - name: Check if the distribution is up to date
-        run: git diff --exit-code HEAD
-
       - name: Upload the distribution as an artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -38,8 +35,15 @@ jobs:
             sample/
             action.yml
 
+  check-build:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the distribution is up to date
+        run: git diff --exit-code HEAD
+
   standard-usage:
-    needs: check-build
+    needs: build
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -74,7 +78,7 @@ jobs:
         uses: ./
 
   llvm-usage:
-    needs: check-build
+    needs: build
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -101,7 +105,7 @@ jobs:
           gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
 
   exclusion-usage:
-    needs: check-build
+    needs: build
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Separate the step for checking the distribution build into an independent job.

This PR prevent other jobs from failing if the distribution is not up to date. Instead, it will use the up to dated distribution from the build job, and check if the currently committed distribution is up to date on a separate job.