### PR TITLE
Modify Workflow to Test Coveralls Send Once 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,13 +223,3 @@ jobs:
         with:
           coveralls-send: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Use this action to generate and send another Coveralls report on a specified output
-        uses: ./
-        with:
-          coveralls-out: coveralls-2.json
-          coveralls-send: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if that Coveralls report does exist
-        run: cat coveralls-2.json


### PR DESCRIPTION
This pull request resolves #143 by removing some steps in the `coveralls-usage` step of the `test` workflow. This modification ensures that the Coveralls send testing only sends report once.