### PR TITLE
Modify Workflow to Test Coveralls Send Only on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,16 +199,12 @@ jobs:
 
   coveralls-usage:
     needs: standard-usage
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Download the project artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: project-with-build-${{ matrix.os }}
+          name: project-with-build-ubuntu
 
       - name: Use this action to generate a Coveralls report
         uses: ./


### PR DESCRIPTION
This pull request resolves #145 by modifying the `coveralls-usage` job in the `test` workflow to run only on Ubuntu.