### PR TITLE
Remove `latest` Branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["*", "!latest"]
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   distribute:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request resolves #158 by removing the `latest` from affecting triggers in the `test` workflow.