### PR TITLE
Seprate Workflows for Build and Test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Cache Dependencies
+        id: cache-npm
+        uses: actions/cache@v4.0.0
+        with:
+          path: node_modules
+          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Dependencies
+        if: steps.cache-npm.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: Build Package
+        run: |
+          npm run clean-build
+          npm run clean-package
+          git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,12 +28,6 @@ jobs:
       - name: Run static analysis
         run: npm run lint
 
-      - name: Build this package
-        run: npm run clean-build
-
-      - name: Build this package for distribution
-        run: npm run clean-package
-
       - name: Upload this project as an artifact
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![latest version](https://img.shields.io/github/v/release/threeal/gcovr-action)](https://github.com/threeal/gcovr-action/releases/)
 [![license](https://img.shields.io/github/license/threeal/gcovr-action)](./LICENSE)
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/build.yaml?branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/test.yml?label=test&branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/test.yml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/test.yaml?label=test&branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/test.yaml)
 
 Generate code coverage reports for a C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![latest version](https://img.shields.io/github/v/release/threeal/gcovr-action)](https://github.com/threeal/gcovr-action/releases/)
 [![license](https://img.shields.io/github/license/threeal/gcovr-action)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/build.yaml?branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/test.yml?label=test&branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/test.yml)
 
 Generate code coverage reports for a C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).


### PR DESCRIPTION
This pull request resolves #157 by introducing the following changes:
- Adds a `build.yaml` workflow.
- Renames the `test.yml` workflow to `test.yaml` workflow.
- Removes the `Build this package` and `Build this package for distribution` steps in the `distribute` job of the `test.yaml` workflow.