### PR TITLE
Only Run Workflows on Ubuntu

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,11 +82,7 @@ jobs:
         uses: ./
 
   llvm-usage:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -103,7 +99,7 @@ jobs:
       - name: Use this action with llvm-cov as the gcov executable
         uses: ./
         with:
-          gcov-executable: ${{ matrix.os == 'macos' && 'xcrun ' || '' }}llvm-cov gcov
+          gcov-executable: llvm-cov gcov
 
   exclusion-usage:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,11 +32,7 @@ jobs:
         run: npm run lint
 
   unit-tests:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,11 +102,7 @@ jobs:
           gcov-executable: llvm-cov gcov
 
   exclusion-usage:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This pull request resolves #165 by modifying the `unit-test`, `llvm-usage`, and `exlcusion-usage` jobs to only be run on the Ubuntu runner: