### PR TITLE
Remove Workflow Dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -150,13 +150,16 @@ jobs:
           fail-under-line: 100
 
   xml-out-usage:
-    needs: standard-usage
     runs-on: ubuntu-latest
     steps:
-      - name: Download the project artifact
-        uses: actions/download-artifact@v3.0.2
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Build and Test Sample Project
+        uses: threeal/cmake-action@v1.3.0
         with:
-          name: project-with-build-ubuntu
+          source-dir: sample
+          run-test: true
 
       - name: Use this action to generate an XML report
         uses: ./

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,15 +69,6 @@ jobs:
           cxx-compiler: g++
           run-test: true
 
-      - name: Upload this project as an artifact
-        uses: actions/upload-artifact@v3.1.3
-        with:
-          name: project-with-build-${{ matrix.os }}
-          path: |
-            *
-            !lib/
-            !node_modules/
-
       - name: Use this action
         uses: ./
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -170,13 +170,16 @@ jobs:
         run: cat coverage.xml
 
   coveralls-usage:
-    needs: standard-usage
     runs-on: ubuntu-latest
     steps:
-      - name: Download the project artifact
-        uses: actions/download-artifact@v3.0.2
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Build and Test Sample Project
+        uses: threeal/cmake-action@v1.3.0
         with:
-          name: project-with-build-ubuntu
+          source-dir: sample
+          run-test: true
 
       - name: Use this action to generate a Coveralls report
         uses: ./


### PR DESCRIPTION
This pull request resolves #167 by removing dependencies between jobs in the `xml-out-usage` and `coveralls-usage` jobs. It also removes the upload artifact step in the `standard-usage` job.