### PR TITLE
Add `.gitattributes` File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+dist/** -diff linguist-generated
+package-lock.json -diff linguist-generated


### PR DESCRIPTION
This pull request resolves #176 by adding a `.gitattributes` file that disable diff and set generated attribute to the `package-lock.json` file and all files under the `dist` directory.