### PR TITLE
Remove Package Name in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "gcovr-action",
       "dependencies": {
         "@actions-kit/envi": "^0.1.0",
         "@actions-kit/exec": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gcovr-action",
   "private": true,
   "scripts": {
     "build": "tsc && ncc build lib/main.js",


### PR DESCRIPTION
This pull request resolves #180 by removing the `name` field from the `package.json` file.