### PR TITLE
Use Prettier with Cache Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "tsc && ncc build lib/main.js",
-    "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
+    "format": "prettier --write --cache \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .ts",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request resolves #186 by modifying the `format` script to call the `prettier` command with the `--cache` option enabled.