### PR TITLE
Set Git Attribute for Yarn Lock File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 dist/** -diff linguist-generated
-package-lock.json -diff linguist-generated
+yarn.lock -diff linguist-generated


### PR DESCRIPTION
This pull request resolves #190 by replacing the Git attribute of the `package-lock.json` file with that of the `yarn.lock` file.