### PR TITLE
Modify `format` Script to Format All Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "tsc && ncc build lib/main.js",
-    "format": "prettier --write --cache \"*.{js,ts,json}\" \"src/**/*.ts\"",
+    "format": "prettier --write --cache . !dist !README.md",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request resolves #196 by modifying the `format` script to format all files except files in the `dist` directory and the `README.md` file.