### PR TITLE
Use Correct Tag in Output XML Report Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
 
 ```yaml
 - name: Generate a code coverage report
-  uses: threeal/gcovr-action@v1.0.0
+  uses: threeal/gcovr-action@xml-out
   with:
     xml-out: coverage.xml
 ```


### PR DESCRIPTION
This pull request resolves #214 by using the correct tag in Output XML Report guide in the `README.md` file.