### PR TITLE
Only Lint Source Files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "root": true,
-  "ignorePatterns": ["dist"],
   "extends": ["eslint:recommended"],
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "tsc && ncc build lib/main.mjs",
     "format": "prettier --write --cache . !dist !README.md",
-    "lint": "eslint --ignore-path .gitignore ."
+    "lint": "eslint src"
   },
   "dependencies": {
     "@actions-kit/envi": "^0.1.0",


### PR DESCRIPTION
This pull request resolves #229 by modifying the `lint` command to only process source files in the `src` directory.