### PR TITLE
Bump pipx-install-action to Version 1.0.0

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -82564,11 +82564,16 @@ var exec_lib = __nccwpck_require__(7221);
 var io = __nccwpck_require__(1793);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-core-npm-1.10.1-3cb1000b4d-10c0.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2340);
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
+
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-cache-npm-3.2.4-c57b047f14-10c0.zip/node_modules/@actions/cache/lib/cache.js
 var cache = __nccwpck_require__(3193);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(4926);
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/pipx/environment.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/pipx/environment.js
+
 
 
 
@@ -82581,7 +82586,7 @@ async function getEnvironment(env) {
         return res.stdout;
     }
     catch (err) {
-        throw new Error(`Failed to get ${env}: ${err.message}`);
+        throw new Error(`Failed to get ${env}: ${r(err)}`);
     }
 }
 function ensurePath() {
@@ -82592,7 +82597,8 @@ function ensurePath() {
     core.addPath(binDir);
 }
 
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/pipx/cache.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/pipx/cache.js
+
 
 
 
@@ -82603,7 +82609,7 @@ async function savePackageCache(pkg) {
         await (0,cache.saveCache)([external_path_.join(binDir, `${pkg}*`), external_path_.join(localVenvs, pkg)], `pipx-${process.platform}-${pkg}`);
     }
     catch (err) {
-        throw new Error(`Failed to save ${pkg} cache: ${err.message}`);
+        throw new Error(`Failed to save ${pkg} cache: ${r(err)}`);
     }
 }
 async function restorePackageCache(pkg) {
@@ -82614,22 +82620,23 @@ async function restorePackageCache(pkg) {
         return key !== undefined;
     }
     catch (err) {
-        throw new Error(`Failed to restore ${pkg} cache: ${err.message}`);
+        throw new Error(`Failed to restore ${pkg} cache: ${r(err)}`);
     }
 }
 
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/pipx/install.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/pipx/install.js
+
 
 async function installPackage(pkg) {
     try {
         await (0,exec.exec)("pipx", ["install", pkg]);
     }
     catch (err) {
-        throw new Error(`Failed to install ${pkg}: ${err.message}`);
+        throw new Error(`Failed to install ${pkg}: ${r(err)}`);
     }
 }
 
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/pipx/index.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/pipx/index.js
 
 
 
@@ -82641,28 +82648,57 @@ async function installPackage(pkg) {
     savePackageCache: savePackageCache,
 });
 
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/action.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/action.js
+
 
 
 async function pipxInstallAction(...pkgs) {
     core.info("Ensuring pipx path...");
-    pipx.ensurePath();
+    try {
+        pipx.ensurePath();
+    }
+    catch (err) {
+        core.setFailed(`Failed to ensure pipx path: ${r(err)}`);
+        return;
+    }
     for (const pkg of pkgs) {
-        const cacheFound = await core.group(`Restoring \u001b[34m${pkg}\u001b[39m cache...`, async () => {
-            return pipx.restorePackageCache(pkg);
-        });
+        let cacheFound;
+        core.startGroup(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
+        try {
+            cacheFound = await pipx.restorePackageCache(pkg);
+        }
+        catch (err) {
+            core.endGroup();
+            core.setFailed(`Failed to restore ${pkg} cache: ${r(err)}`);
+            return;
+        }
+        core.endGroup();
         if (!cacheFound) {
-            await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
+            core.startGroup(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
+            try {
                 await pipx.installPackage(pkg);
-            });
-            await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
+            }
+            catch (err) {
+                core.endGroup();
+                core.setFailed(`Failed to install ${pkg}: ${r(err)}`);
+                return;
+            }
+            core.endGroup();
+            core.startGroup(`Saving \u001b[34m${pkg}\u001b[39m cache...`);
+            try {
                 await pipx.savePackageCache(pkg);
-            });
+            }
+            catch (err) {
+                core.endGroup();
+                core.setFailed(`Failed to save ${pkg} cache: ${r(err)}`);
+                return;
+            }
+            core.endGroup();
         }
     }
 }
 
-;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-https-c5991cd929-10c0.zip/node_modules/pipx-install-action/src/index.mjs
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/pipx-install-action-npm-1.0.0-9cbf40e0d9-10c0.zip/node_modules/pipx-install-action/dist/index.js
 
 
 ;// CONCATENATED MODULE: ./lib/deps/index.mjs

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@actions/core": "^1.10.1",
     "@actions/io": "^1.1.3",
     "form-data": "^4.0.0",
-    "pipx-install-action": "https://github.com/threeal/pipx-install-action#dist"
+    "pipx-install-action": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,6 +757,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -1863,16 +1870,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pipx-install-action@https://github.com/threeal/pipx-install-action#dist":
-  version: 0.1.0
-  resolution: "pipx-install-action@https://github.com/threeal/pipx-install-action.git#commit=740d558bbe81839d18bd11bfbd95a4e16a43d7aa"
+"pipx-install-action@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "pipx-install-action@npm:1.0.0"
   dependencies:
     "@actions/cache": "npm:^3.2.4"
     "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
-  bin:
-    pipx-install-action: src/main.mjs
-  checksum: 10c0/6266ba3f49391c8e7fc3fe5a8009a598d2b27f478ddf77658f6d0adea4e3bbdba9488a3593f8e575f4e484f9f2678bfd1472d2ec6aeb070adefb0516286bf84b
+    catched-error-message: "npm:^0.0.1"
+  checksum: 10c0/a2044259a51a1e2c4fdca1b2819c5f9fd47eb7cd5ac2ee93522b639751607e720d8f381c0aa43cec5211402ea438085298641411059a3d1c5f90cdfc2bf69382
   languageName: node
   linkType: hard
 
@@ -1978,7 +1984,7 @@ __metadata:
     "@vercel/ncc": "npm:^0.38.1"
     eslint: "npm:^8.57.0"
     form-data: "npm:^4.0.0"
-    pipx-install-action: "https://github.com/threeal/pipx-install-action#dist"
+    pipx-install-action: "npm:^1.0.0"
     prettier: "npm:^3.2.4"
     typescript: "npm:^5.4.2"
   languageName: unknown


### PR DESCRIPTION
This pull request simply bumps the [pipx-install-action](https://github.com/threeal/pipx-install-action) to the version [1.0.0](https://github.com/threeal/pipx-install-action/releases/tag/v1.0.0).