### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Gcovr Action
 
-[![latest version](https://img.shields.io/github/v/release/threeal/gcovr-action)](https://github.com/threeal/gcovr-action/releases/)
-[![license](https://img.shields.io/github/license/threeal/gcovr-action)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/build.yaml?branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/gcovr-action/test.yaml?label=test&branch=main)](https://github.com/threeal/gcovr-action/actions/workflows/test.yaml)
-
 Generate code coverage reports for a C++ project on [GitHub Actions](https://github.com/features/actions) using [gcovr](https://gcovr.com/en/stable/).
 
 ## Features


### PR DESCRIPTION
This pull request resolves #248 by simply removing badges from the root `README.md` file.