### PR TITLE
Modify `github-token` Input to be Optional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -166,4 +166,3 @@ jobs:
         uses: ./
         with:
           coveralls-send: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | `xml-out` | Path | Output file of the generated XML coverage report. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
 | `coveralls-send` | `true` or `false` | Send the generated Coveralls API coverage report to it's endpoint. Defaults to `false`. |
-| `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Should be set to `secrets.GITHUB_TOKEN`. Required for sending Coveralls API coverage report successfully. |
+| `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Defaults to [`github.token`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). Required for sending Coveralls API coverage report successfully. |
 
 > Note: All inputs are optional.
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ inputs:
     default: false
   github-token:
     description: GitHub token of your project
+    default: ${{ github.token }}
 runs:
   using: node20
   main: dist/index.mjs

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -82181,14 +82181,7 @@ async function run(inputs) {
     const args = getArgs(inputs);
     await core.group("Generating code coverage report...", async () => {
         if (inputs.githubToken.length > 0) {
-            core.info(`Setting \u001b[34m$COVERALLS_REPO_TOKEN\u001b[39m to \u001b[34m${inputs.githubToken}\u001b[39m...`);
-            try {
-                core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-            }
-            catch (err) {
-                const errMessage = `${err instanceof Error ? err.message : err}`;
-                throw new Error(`Failed to set \u001b[34m$COVERALLS_REPO_TOKEN\u001b[39m to ${inputs.githubToken}: ${errMessage}`);
-            }
+            core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
         }
         const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
         if (status !== 0) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -82180,9 +82180,7 @@ function getArgs(inputs) {
 async function run(inputs) {
     const args = getArgs(inputs);
     await core.group("Generating code coverage report...", async () => {
-        if (inputs.githubToken.length > 0) {
-            core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-        }
+        core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
         const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
         if (status !== 0) {
             let errMessage;

--- a/src/gcovr.mts
+++ b/src/gcovr.mts
@@ -30,17 +30,7 @@ export async function run(inputs: action.Inputs) {
   const args = getArgs(inputs);
   await core.group("Generating code coverage report...", async () => {
     if (inputs.githubToken.length > 0) {
-      core.info(
-        `Setting \u001b[34m$COVERALLS_REPO_TOKEN\u001b[39m to \u001b[34m${inputs.githubToken}\u001b[39m...`,
-      );
-      try {
-        core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-      } catch (err) {
-        const errMessage = `${err instanceof Error ? err.message : err}`;
-        throw new Error(
-          `Failed to set \u001b[34m$COVERALLS_REPO_TOKEN\u001b[39m to ${inputs.githubToken}: ${errMessage}`,
-        );
-      }
+      core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
     }
     const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
     if (status !== 0) {

--- a/src/gcovr.mts
+++ b/src/gcovr.mts
@@ -29,9 +29,7 @@ function getArgs(inputs: action.Inputs): string[] {
 export async function run(inputs: action.Inputs) {
   const args = getArgs(inputs);
   await core.group("Generating code coverage report...", async () => {
-    if (inputs.githubToken.length > 0) {
-      core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-    }
+    core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
     const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
     if (status !== 0) {
       let errMessage: string;


### PR DESCRIPTION
This pull request resolves #250 by introducing the following changes:
- Sets the `github-token` input defaults to `${{ github.token }}`.
- Modifies the action to always export the `COVERALLS_REPO_TOKEN` variable silently, without logging any information.