### PR TITLE
Set `COVERALLS_REPO_TOKEN` Variable Only During Gcovr Command Execution

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -82180,8 +82180,12 @@ function getArgs(inputs) {
 async function run(inputs) {
     const args = getArgs(inputs);
     await core.group("Generating code coverage report...", async () => {
-        core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-        const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
+        const status = await exec.exec("gcovr", args, {
+            ignoreReturnCode: true,
+            env: {
+                COVERALLS_REPO_TOKEN: inputs.githubToken,
+            },
+        });
         if (status !== 0) {
             let errMessage;
             if ((status | 2) > 0) {

--- a/src/gcovr.mts
+++ b/src/gcovr.mts
@@ -29,8 +29,12 @@ function getArgs(inputs: action.Inputs): string[] {
 export async function run(inputs: action.Inputs) {
   const args = getArgs(inputs);
   await core.group("Generating code coverage report...", async () => {
-    core.exportVariable("COVERALLS_REPO_TOKEN", inputs.githubToken);
-    const status = await exec.exec("gcovr", args, { ignoreReturnCode: true });
+    const status = await exec.exec("gcovr", args, {
+      ignoreReturnCode: true,
+      env: {
+        COVERALLS_REPO_TOKEN: inputs.githubToken,
+      },
+    });
     if (status !== 0) {
       let errMessage: string;
       if ((status | 2) > 0) {


### PR DESCRIPTION
This pull request resolves #252 by modifying the `COVERALLS_REPO_TOKEN` variable. Instead of exporting that variable to a global scope, this change modifies it to be set directly during the execution of the Gcovr command.