### PR TITLE
Run ESLint with No File Arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "ncc build src/main.ts",
     "format": "prettier --write --cache . !dist !README.md",
-    "lint": "eslint ."
+    "lint": "eslint"
   },
   "dependencies": {
     "@actions/cache": "^3.2.3",


### PR DESCRIPTION
This pull request simply resolves #289 by modifying the `lint` script in the `package.json` file to run the `eslint` command with no file arguments.