### PR TITLE
Enable TypeScript Strict Configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
     "module": "node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
     "target": "es2022"
   }
 }


### PR DESCRIPTION
This pull request resolves #377 by enabling TypeScript strict configuration and setting it to skip library checks.