### PR TITLE
Unspecify Yarn Version in GitHub Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Build Package
         run: yarn build

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Check Format
         run: yarn format


### PR DESCRIPTION
This pull request resolves #401 by not specifying the Yarn version when setting up Yarn in GitHub workflows.