### PR TITLE
Add options for failing on branch and function coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: ./
         with:
           root: sample
-          fail-under-line: 50
+          fail-under-line: 20
 
       - name: Use this action with an exclusion
         uses: ./
@@ -119,6 +119,90 @@ jobs:
             sample/include/is_even.hpp
             sample/include/is_odd.hpp
           fail-under-line: 100
+
+  branch-and-function-usage:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v5
+
+      - name: Build Sample Project
+        uses: threeal/cmake-action@v2.0.0
+        with:
+          source-dir: sample
+          generator: Ninja
+          cxx-compiler: g++
+          options: |
+            TEST_EVEN=OFF
+
+      - name: Test Sample Project
+        uses: threeal/ctest-action@v1.1.0
+        with:
+          test-dir: sample/build
+
+      - name: Test branch coverage above threshold
+        id: failed_branch_step
+        continue-on-error: true
+        uses: ./
+        with:
+          root: sample
+          fail-under-branch: 100
+
+      - name: Check if the previous step did fail
+        run: ${{ steps.failed_branch_step.outcome == 'failure' && true || false }}
+
+      - name: Test branch coverage below threshold
+        uses: ./
+        with:
+          root: sample
+          fail-under-branch: 25
+
+      - name: Test function coverage above threshold
+        id: failed_function_step
+        continue-on-error: true
+        uses: ./
+        with:
+          root: sample
+          fail-under-function: 100
+
+      - name: Check if the previous step did fail
+        run: ${{ steps.failed_function_step.outcome == 'failure' && true || false }}
+
+      - name: Test branch coverage below threshold
+        uses: ./
+        with:
+          root: sample
+          fail-under-function: 50
+
+  working-directory-usage:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v5
+
+      - name: Build Sample Project
+        uses: threeal/cmake-action@v2.0.0
+        with:
+          source-dir: sample
+          generator: Ninja
+          cxx-compiler: g++
+
+      - name: Test Sample Project
+        uses: threeal/ctest-action@v1.1.0
+        with:
+          test-dir: sample/build
+
+      - name: Use this action with a different working directory
+        uses: ./
+        with:
+          working-directory: sample/build
+          root: ../
 
   html-out-usage:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | `gcov-executable` | Executable name with optional arguments | Use a particular [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) executable. Must match the compiler you are using, e.g. `llvm-cov gcov` for [LLVM Clang](https://clang.llvm.org/). See [this](https://gcovr.com/en/stable/guide/compiling.html#choosing-the-right-gcov-executable). |
 | `excludes` | One or more regular expression | Exclude source files that match these filters. |
 | `fail-under-line` | 0 - 100 | Fail if the total line coverage is less than this value. |
+| `fail-under-branch` | 0 - 100 | Fail if the total branch coverage is less than this value. |
+| `fail-under-function` | 0 - 100 | Fail if the total function coverage is less than this value. |
 | `html-out` | Path | Output file of the generated HTML coverage report. |
 | `html-theme` | `green` , `blue` , `github.blue` , `github.green` , `github.dark-green` , `github.dark-blue` | Override the default color theme for the HTML report. |
 | `xml-out` | Path | Output file of the generated XML coverage report. |
 | `coveralls-out` | Path | Output file of the generated [Coveralls API](https://docs.coveralls.io/api-introduction) coverage report. |
 | `coveralls-send` | `true` or `false` | Send the generated Coveralls API coverage report to it's endpoint. Defaults to `false`. |
 | `github-token` | Token | [GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) of your project. Defaults to [`github.token`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). Required for sending Coveralls API coverage report successfully. |
+| `working-directory` | Path | Working directory where gcovr should be executed from. |
 
 > Note: All inputs are optional.
 
@@ -117,6 +120,18 @@ jobs:
     coveralls-send: true
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+#### Specify Alternate Working Directory
+Note that `working-directory` and `root` will almost always be used together, in which case `root` is evaluated relative to the specified working directory. In other words it is passed directly through as an argument to `gcovr`.
+
+```yaml
+- name: Generate a code coverage report
+  uses: threeal/gcovr-action@v1.0.0
+  with:
+    working-directory: build
+    root: ../
+```
+
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Exclude source files that match these filters
   fail-under-line:
     description: Fail if the total line coverage is less than this value
+  fail-under-branch:
+    description: Fail if the total branch coverage is less than this value
+  fail-under-function:
+    description: Fail if the total function coverage is less than this value
   html-out:
     description: Output file of the generated HTML coverage report
   html-theme:
@@ -27,6 +31,8 @@ inputs:
   github-token:
     description: GitHub token of your project
     default: ${{ github.token }}
+  working-directory:
+    description: Working directory where gcovr should be executed from
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -84058,12 +84058,15 @@ function processInputs() {
                 .map((val) => val.trim())
                 .filter((val) => val !== ""),
             failUnderLine: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("fail-under-line"),
+            failUnderBranch: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("fail-under-branch"),
+            failUnderFunction: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("fail-under-function"),
             htmlOut: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("html-out"),
             htmlTheme: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("html-theme"),
             xmlOut: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("xml-out"),
             coverallsOut: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("coveralls-out"),
             coverallsSend: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("coveralls-send") === "true",
             githubToken: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("github-token"),
+            workingDirectory: (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("working-directory"),
         };
         // Auto set coveralls output if not specified
         if (inputs.coverallsSend && inputs.coverallsOut.length <= 0) {
@@ -92339,17 +92342,27 @@ async function check() {
 
 /***/ }),
 
-/***/ 6840:
+/***/ 4515:
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   "K": () => (/* binding */ run)
-/* harmony export */ });
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4926);
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var catched_error_message__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(144);
-/* harmony import */ var gha_utils__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(9720);
-/* harmony import */ var _coveralls_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(2075);
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "K": () => (/* binding */ run)
+});
+
+// EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
+var exec = __nccwpck_require__(4926);
+// EXTERNAL MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+var index_esm = __nccwpck_require__(144);
+// EXTERNAL MODULE: ../../../.yarn/berry/cache/gha-utils-npm-0.3.0-2043836e46-10c0.zip/node_modules/gha-utils/dist/index.js + 5 modules
+var dist = __nccwpck_require__(9720);
+// EXTERNAL MODULE: ./src/coveralls.ts + 50 modules
+var coveralls = __nccwpck_require__(2075);
+;// CONCATENATED MODULE: external "process"
+const external_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("process");
+;// CONCATENATED MODULE: ./src/gcovr.ts
+
 
 
 
@@ -92368,6 +92381,12 @@ function getArgs(inputs) {
     if (inputs.failUnderLine.length > 0) {
         args = args.concat("--fail-under-line", inputs.failUnderLine);
     }
+    if (inputs.failUnderBranch.length > 0) {
+        args = args.concat("--fail-under-branch", inputs.failUnderBranch);
+    }
+    if (inputs.failUnderFunction.length > 0) {
+        args = args.concat("--fail-under-function", inputs.failUnderFunction);
+    }
     if (inputs.htmlOut.length > 0) {
         args = args.concat("--html", inputs.htmlOut);
     }
@@ -92384,9 +92403,13 @@ function getArgs(inputs) {
 }
 async function run(inputs) {
     const args = getArgs(inputs);
-    (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .beginLogGroup */ .zq)("Generating code coverage report...");
+    (0,dist/* beginLogGroup */.zq)("Generating code coverage report...");
+    if (inputs.workingDirectory.length > 0) {
+        external_process_namespaceObject.chdir(inputs.workingDirectory);
+        console.log(`Current directory: ${external_process_namespaceObject.cwd()}`);
+    }
     try {
-        const status = await _actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec("gcovr", args, {
+        const status = await exec.exec("gcovr", args, {
             ignoreReturnCode: true,
             env: {
                 COVERALLS_REPO_TOKEN: inputs.githubToken,
@@ -92395,7 +92418,7 @@ async function run(inputs) {
         if (status !== 0) {
             let errMessage;
             if ((status | 2) > 0) {
-                errMessage = `coverage is under ${inputs.failUnderLine}%`;
+                errMessage = `coverage is under configured targets.`;
             }
             else {
                 errMessage = `unknown error (error code ${status})`;
@@ -92403,21 +92426,21 @@ async function run(inputs) {
             throw new Error(`Failed to generate code coverage report: ${errMessage}`);
         }
         if (inputs.coverallsOut.length > 0) {
-            (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logInfo */ .PN)("Patching Coveralls API report...");
+            (0,dist/* logInfo */.PN)("Patching Coveralls API report...");
             try {
-                _coveralls_js__WEBPACK_IMPORTED_MODULE_2__/* .patch */ .r(inputs.coverallsOut);
+                coveralls/* patch */.r(inputs.coverallsOut);
             }
             catch (err) {
-                throw new Error(`Failed to patch Coveralls API report: ${(0,catched_error_message__WEBPACK_IMPORTED_MODULE_3__/* .getErrorMessage */ .e)(err)}`);
+                throw new Error(`Failed to patch Coveralls API report: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
             }
-            (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logInfo */ .PN)(`Coveralls API report outputted to \u001b[34m${inputs.coverallsOut}\u001b[39m`);
+            (0,dist/* logInfo */.PN)(`Coveralls API report outputted to \u001b[34m${inputs.coverallsOut}\u001b[39m`);
         }
     }
     catch (err) {
-        (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .endLogGroup */ .sH)();
+        (0,dist/* endLogGroup */.sH)();
         throw err;
     }
-    (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .endLogGroup */ .sH)();
+    (0,dist/* endLogGroup */.sH)();
 }
 
 
@@ -92431,7 +92454,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _action_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(3858);
 /* harmony import */ var _coveralls_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(2075);
 /* harmony import */ var _deps_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(2190);
-/* harmony import */ var _gcovr_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(6840);
+/* harmony import */ var _gcovr_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(4515);
 
 
 

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.6.0"
   },
-  "packageManager": "yarn@4.4.1"
+  "packageManager": "yarn@4.5.0"
 }

--- a/sample/include/is_even.hpp
+++ b/sample/include/is_even.hpp
@@ -1,3 +1,13 @@
 #pragma once
 
-bool is_even(int val) { return val % 2 == 0; }
+#include <iostream>
+
+bool is_even(int val) {
+    bool result = ((val % 2) == 0);
+    if (result) {
+        std::cout << "Result is even\n";
+    } else {
+        std::cout << "Result is odd\n";
+    }
+    return result;
+}

--- a/sample/include/is_odd.hpp
+++ b/sample/include/is_odd.hpp
@@ -1,3 +1,13 @@
 #pragma once
 
-bool is_odd(int val) { return val % 2 == 1; }
+#include <iostream>
+
+bool is_odd(int val) {
+    bool result = ((val % 2) == 1);
+    if (result) {
+        std::cout << "Result is odd\n";
+    } else {
+        std::cout << "Result is even\n";
+    }
+    return result;
+}

--- a/src/action.ts
+++ b/src/action.ts
@@ -8,12 +8,15 @@ export interface Inputs {
   gcovExecutable: string;
   excludes: string[];
   failUnderLine: string;
+  failUnderBranch: string;
+  failUnderFunction: string;
   htmlOut: string;
   htmlTheme: string;
   xmlOut: string;
   coverallsOut: string;
   coverallsSend: boolean;
   githubToken: string;
+  workingDirectory: string;
 }
 
 export function processInputs(): Inputs {
@@ -27,12 +30,15 @@ export function processInputs(): Inputs {
         .map((val) => val.trim())
         .filter((val) => val !== ""),
       failUnderLine: getInput("fail-under-line"),
+      failUnderBranch: getInput("fail-under-branch"),
+      failUnderFunction: getInput("fail-under-function"),
       htmlOut: getInput("html-out"),
       htmlTheme: getInput("html-theme"),
       xmlOut: getInput("xml-out"),
       coverallsOut: getInput("coveralls-out"),
       coverallsSend: getInput("coveralls-send") === "true",
       githubToken: getInput("github-token"),
+      workingDirectory: getInput("working-directory"),
     };
     // Auto set coveralls output if not specified
     if (inputs.coverallsSend && inputs.coverallsOut.length <= 0) {

--- a/src/gcovr.ts
+++ b/src/gcovr.ts
@@ -3,6 +3,7 @@ import { getErrorMessage } from "catched-error-message";
 import { beginLogGroup, endLogGroup, logInfo } from "gha-utils";
 import * as action from "./action.js";
 import * as coveralls from "./coveralls.js";
+import * as process from "process";
 
 function getArgs(inputs: action.Inputs): string[] {
   let args: string[] = [];
@@ -17,6 +18,12 @@ function getArgs(inputs: action.Inputs): string[] {
   }
   if (inputs.failUnderLine.length > 0) {
     args = args.concat("--fail-under-line", inputs.failUnderLine);
+  }
+  if (inputs.failUnderBranch.length > 0) {
+    args = args.concat("--fail-under-branch", inputs.failUnderBranch);
+  }
+  if (inputs.failUnderFunction.length > 0) {
+    args = args.concat("--fail-under-function", inputs.failUnderFunction);
   }
   if (inputs.htmlOut.length > 0) {
     args = args.concat("--html", inputs.htmlOut);
@@ -36,6 +43,10 @@ function getArgs(inputs: action.Inputs): string[] {
 export async function run(inputs: action.Inputs) {
   const args = getArgs(inputs);
   beginLogGroup("Generating code coverage report...");
+  if (inputs.workingDirectory.length > 0) {
+    process.chdir(inputs.workingDirectory);
+    console.log(`Current directory: ${process.cwd()}`);
+  }
   try {
     const status = await exec.exec("gcovr", args, {
       ignoreReturnCode: true,
@@ -46,7 +57,7 @@ export async function run(inputs: action.Inputs) {
     if (status !== 0) {
       let errMessage: string;
       if ((status | 2) > 0) {
-        errMessage = `coverage is under ${inputs.failUnderLine}%`;
+        errMessage = `coverage is under configured targets.`;
       } else {
         errMessage = `unknown error (error code ${status})`;
       }


### PR DESCRIPTION
# Summary of changes
  - Adds option `fail-under-branch` for failing a CI check on insufficient branch coverage
  - Adds option `fail-under-function` for failing a CI check on insufficient function coverage
  - Adds option `working-directory` for executing gcovr from a location other than project root
  - Adds workflow support for testing the above options, including some updates to the `sample` C++ project to generate non-trivial branch coverage info