### PR TITLE
Configure Dependabot Label to Empty

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
+    labels: []
 
   - package-ecosystem: npm
     directory: /
@@ -14,5 +14,5 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
+    labels: []
     versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #514 by configuring Dependabot labels in the `dependabot.yaml` file to an empty array, ensuring that Dependabot won't assign any labels to newly created pull requests.