### PR TITLE
Extend TypeScript Configuration from Node.js Base Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@tsconfig/node23": "^23.0.0",
     "@types/node": "^22.13.9",
     "@vercel/ncc": "^0.38.3",
     "eslint": "^9.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.22.0
         version: 9.22.0
+      '@tsconfig/node23':
+        specifier: ^23.0.0
+        version: 23.0.0
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.10
@@ -241,6 +244,9 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tsconfig/node23@23.0.0':
+    resolution: {integrity: sha512-a2qO9QOEWnomKbFFE3XlOJ5za6Sc+XduxQkFpah42enbTPFPaW0QzKw616KDNfmMLPhXMwCw4EHVjcKaFOj/OA==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1188,6 +1194,8 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tsconfig/node23@23.0.0': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,6 @@
 {
+  "extends": "@tsconfig/node23",
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "strict": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "esModuleInterop": true,
-    "target": "es2022",
-    "skipLibCheck": true
+    "module": "node16"
   }
 }


### PR DESCRIPTION
This pull request resolves #581 by extending `tsconfig.json` from [@tsconfig/node23](https://www.npmjs.com/package/@tsconfig/node23).