### PR TITLE
Remove Unnecessary Configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,5 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
-  {
-    ignores: [".*", "dist"],
-  },
+  { ignores: ["dist"] },
 ];


### PR DESCRIPTION
This pull request resolves #632 by removing `.*` files from being ignored in `eslint.config.js`.  