### PR TITLE
Strict TypeScript ESLint Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -70739,7 +70739,7 @@ const got = source_create(defaults);
 
 
 
-async function patch(coverallsOut) {
+function patch(coverallsOut) {
     let data = external_fs_.readFileSync(coverallsOut).toString();
     data = data.replaceAll('"service_name": "github-actions-ci"', '"service_name": "github"');
     external_fs_.writeFileSync(coverallsOut, data);
@@ -70752,7 +70752,7 @@ async function send(coverallsOut) {
         const res = await got_dist_source.post("https://coveralls.io/api/v1/jobs", {
             body: form,
         });
-        (0,dist/* logInfo */.fH)(`HTTP status code ${res.statusCode}: ${res.body}`);
+        (0,dist/* logInfo */.fH)(`HTTP status code ${res.statusCode.toString()}: ${res.body}`);
     }
     catch (err) {
         (0,dist/* endLogGroup */.NZ)();
@@ -71052,7 +71052,7 @@ function getArgs(inputs) {
         if (typeof inputs.jobs === "number") {
             args = args.concat("-j", inputs.jobs.toString());
         }
-        else if (typeof inputs.jobs === "boolean" && inputs.jobs) {
+        else if (typeof inputs.jobs === "boolean") {
             args = args.concat("-j");
         }
     }
@@ -71081,7 +71081,7 @@ async function run(inputs) {
                 errMessage = `coverage is under configured targets.`;
             }
             else {
-                errMessage = `unknown error (error code ${status})`;
+                errMessage = `unknown error (error code ${status.toString()})`;
             }
             throw new Error(`Failed to generate code coverage report: ${errMessage}`);
         }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
-  { ignores: ["dist"] },
-];
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,9 +10,7 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ["eslint.config.js"],
-        },
+        projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^22.15.30",
     "@vercel/ncc": "^0.38.3",
     "eslint": "^9.29.0",
+    "jiti": "^2.4.2",
     "lefthook": "^1.11.13",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,10 @@ importers:
         version: 0.38.3
       eslint:
         specifier: ^9.29.0
-        version: 9.29.0
+        version: 9.29.0(jiti@2.4.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       lefthook:
         specifier: ^1.11.13
         version: 1.11.13
@@ -59,7 +62,7 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.34.1
-        version: 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+        version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
 
 packages:
 
@@ -665,6 +668,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1161,9 +1168,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1277,15 +1284,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1294,14 +1301,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1324,12 +1331,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1353,13 +1360,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1503,9 +1510,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.29.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.3
@@ -1540,6 +1547,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1729,6 +1738,8 @@ snapshots:
   is-stream@4.0.1: {}
 
   isexe@2.0.0: {}
+
+  jiti@2.4.2: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -1944,12 +1955,12 @@ snapshots:
 
   type-fest@4.36.0: {}
 
-  typescript-eslint@8.34.1(eslint@9.29.0)(typescript@5.8.3):
+  typescript-eslint@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color

--- a/src/coveralls.ts
+++ b/src/coveralls.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { beginLogGroup, endLogGroup, logInfo } from "gha-utils";
 import got from "got";
 
-export async function patch(coverallsOut: string) {
+export function patch(coverallsOut: string) {
   let data: string = fs.readFileSync(coverallsOut).toString();
   data = data.replaceAll(
     '"service_name": "github-actions-ci"',
@@ -22,7 +22,7 @@ export async function send(coverallsOut: string) {
     const res = await got.post("https://coveralls.io/api/v1/jobs", {
       body: form,
     });
-    logInfo(`HTTP status code ${res.statusCode}: ${res.body}`);
+    logInfo(`HTTP status code ${res.statusCode.toString()}: ${res.body}`);
   } catch (err) {
     endLogGroup();
     throw err;

--- a/src/gcovr.ts
+++ b/src/gcovr.ts
@@ -86,7 +86,7 @@ function getArgs(inputs: action.Inputs): string[] {
   if (inputs.jobs) {
     if (typeof inputs.jobs === "number") {
       args = args.concat("-j", inputs.jobs.toString());
-    } else if (typeof inputs.jobs === "boolean" && inputs.jobs) {
+    } else if (typeof inputs.jobs === "boolean") {
       args = args.concat("-j");
     }
   }
@@ -115,7 +115,7 @@ export async function run(inputs: action.Inputs) {
       if ((status | 2) > 0) {
         errMessage = `coverage is under configured targets.`;
       } else {
-        errMessage = `unknown error (error code ${status})`;
+        errMessage = `unknown error (error code ${status.toString()})`;
       }
       throw new Error(`Failed to generate code coverage report: ${errMessage}`);
     }


### PR DESCRIPTION
This pull request resolves #646 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.