### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 build/
 node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -70959,10 +70959,10 @@ var exec = __nccwpck_require__(8872);
 var index_esm = __nccwpck_require__(4214);
 // EXTERNAL MODULE: ./node_modules/.pnpm/gha-utils@0.4.1/node_modules/gha-utils/dist/index.js + 5 modules
 var dist = __nccwpck_require__(8222);
-// EXTERNAL MODULE: ./src/coveralls.ts + 47 modules
-var coveralls = __nccwpck_require__(5388);
 ;// CONCATENATED MODULE: external "process"
 const external_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("process");
+// EXTERNAL MODULE: ./src/coveralls.ts + 47 modules
+var coveralls = __nccwpck_require__(5388);
 ;// CONCATENATED MODULE: ./src/gcovr.ts
 
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jiti": "^2.4.2",
     "lefthook": "^1.12.2",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -845,6 +848,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -1881,6 +1894,11 @@ snapshots:
       - supports-color
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
 
   prettier@3.6.2: {}
 

--- a/src/gcovr.ts
+++ b/src/gcovr.ts
@@ -1,9 +1,9 @@
 import * as exec from "@actions/exec";
 import { getErrorMessage } from "catched-error-message";
 import { beginLogGroup, endLogGroup, logInfo } from "gha-utils";
+import * as process from "process";
 import * as action from "./action.js";
 import * as coveralls from "./coveralls.js";
-import * as process from "process";
 
 function getArgs(inputs: action.Inputs): string[] {
   let args: string[] = [];


### PR DESCRIPTION
This pull request resolves #679 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.