### PR TITLE
Fix Unsupported CMake Minimum Version in CI Test

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(test)
 
 option(TEST_EVEN "test is_even function" ON)


### PR DESCRIPTION
This pull request resolves #716 by bumping the minimum required CMake version in the sample project for CI testing to 3.5.
