### PR TITLE
Remove Setup Ninja Action in CI Workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Build Sample Project
         uses: threeal/cmake-action@v2.1.0
         with:
@@ -42,9 +39,6 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install -y llvm
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Build Sample Project
         uses: threeal/cmake-action@v2.1.0
         with:
@@ -68,9 +62,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
-
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: Build Sample Project
         uses: threeal/cmake-action@v2.1.0
@@ -126,9 +117,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Build Sample Project
         uses: threeal/cmake-action@v2.1.0
         with:
@@ -182,9 +170,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
-
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: Build Sample Project
         uses: threeal/cmake-action@v2.1.0


### PR DESCRIPTION
This pull request resolves #722 by removing the `seanmiddleditch/gha-setup-ninja` action from the CI workflow.