### PR TITLE
Use cooldown configuration in Dependabot for npm packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,4 +9,6 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 1
     versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #850 by adding a 1-day cooldown period to the Dependabot npm configuration so PRs are only created for package versions published at least 24 hours ago.